### PR TITLE
IPAM can now query for generic IP management information

### DIFF
--- a/tests/test_addr_view.py
+++ b/tests/test_addr_view.py
@@ -1,0 +1,116 @@
+"""
+A suite of tests for the AddrView object
+"""
+import unittest
+from unittest.mock import patch, MagicMock
+
+import ujson
+from flask import Flask
+from vlab_api_common import flask_common
+from vlab_api_common.http_auth import generate_v2_test_token
+
+
+from vlab_ipam_api.lib.views import addr
+
+
+class TestAddrView(unittest.TestCase):
+    """A set of test cases for the AddrView object"""
+
+    @classmethod
+    def setUpClass(cls):
+        """Runs once for the whole test suite"""
+        cls.token = generate_v2_test_token(username='bob')
+        addr.const = MagicMock()
+        addr.const.VLAB_IPAM_OWNER = 'bob'
+        addr.const.VLAB_IPAM_LOG_LEVEL = 'INFO'
+        addr.const.VLAB_VERIFY_TOKEN = False
+
+    @classmethod
+    def setUp(cls):
+        """Runs before every test case"""
+        app = Flask(__name__)
+        addr.AddrView.register(app)
+        app.config['TESTING'] = True
+        cls.app = app.test_client()
+        # Mock logger
+        cls.fake_logger = MagicMock()
+        addr.logger = cls.fake_logger
+
+    @patch.object(addr, 'Database')
+    def test_get(self, fake_Database):
+        """GET on /api/1/ipam/addr returns 200 OK upon success"""
+        resp = self.app.get('/api/1/ipam/addr',
+                            headers={'X-Auth': self.token})
+
+        expected = 200
+
+        self.assertEqual(resp.status_code, expected)
+
+    @patch.object(addr, 'args_valid')
+    def test_get_bad_args(self, fake_args_valid):
+        """GET on /api/1/ipam/addr returns 400 if supplied with bad query parameters"""
+        fake_args_valid.return_value = False
+        resp = self.app.get('/api/1/ipam/addr',
+                            headers={'X-Auth': self.token})
+
+        expected = 400
+
+        self.assertEqual(resp.status_code, expected)
+
+    def test_args_valid_none(self):
+        """``args_valid`` a value of None for all args is OK"""
+        output = addr.args_valid(name=None, addr=None, component=None)
+
+        self.assertTrue(output)
+
+    def test_args_valid_name(self):
+        """``args_valid`` returns True if supplied with just the "name" param"""
+        output = addr.args_valid(name='someBox', addr=None, component=None)
+
+        self.assertTrue(output)
+
+    def test_args_valid_addr(self):
+        """``args_valid`` returns True if supplied with just a valid IPv4 param"""
+        output = addr.args_valid(name=None, addr='1.2.3.4', component=None)
+
+        self.assertTrue(output)
+
+    def test_args_valid_component(self):
+        """``args_valid`` returns True if supplied with just the "component" param"""
+        output = addr.args_valid(name=None, addr='', component='someComponent')
+
+        self.assertTrue(output)
+
+    def test_args_valid_name_and_addr(self):
+        """``args_valid`` returns False if supplied with both name and addr param"""
+        output = addr.args_valid(name='myBox', addr='1.2.3.4', component=None)
+
+        self.assertFalse(output)
+
+    def test_args_valid_name_and_component(self):
+        """``args_valid`` returns False if supplied with both name and component param"""
+        output = addr.args_valid(name='myBox', addr='', component='someComponent')
+
+        self.assertFalse(output)
+
+    def test_args_valid_component_and_addr(self):
+        """``args_valid`` returns False if supplied with both component and addr param"""
+        output = addr.args_valid(name=None, addr='1.2.3.4', component='someComponent')
+
+        self.assertFalse(output)
+
+    def test_args_valid_all_params(self):
+        """``args_valid`` returns False if supplied with all params"""
+        output = addr.args_valid(name='myBox', addr='1.2.3.4', component='someComponent')
+
+        self.assertFalse(output)
+
+    def test_args_valid_bad_ip(self):
+        """``args_valid`` returns False if supplied with an invalid IPv4 address"""
+        output = addr.args_valid(name=None, addr='900.2.3.4', component=None)
+
+        self.assertFalse(output)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -5,7 +5,7 @@ A suite of tests for the HTTP API schemas
 import unittest
 
 from jsonschema import Draft4Validator, validate, ValidationError
-from vlab_ipam_api.lib.views import portmap
+from vlab_ipam_api.lib.views import portmap, addr
 
 
 class TestIpamViewSchema(unittest.TestCase):
@@ -36,6 +36,20 @@ class TestIpamViewSchema(unittest.TestCase):
         """The schema defined for DELETE on is valid"""
         try:
             Draft4Validator.check_schema(portmap.PortMapView.DELETE_SCHEMA)
+            schema_valid = True
+        except RuntimeError:
+            schema_valid = False
+
+        self.assertTrue(schema_valid)
+
+
+class TestAddrViewSchema(unittest.TestCase):
+    """A set of test cases for the schemas of /api/1/ipam/addr"""
+
+    def test_get_args(self):
+        """The schema defined for the query params on GET is valid"""
+        try:
+            Draft4Validator.check_schema(addr.AddrView.GET_ARGS_SCHEMA)
             schema_valid = True
         except RuntimeError:
             schema_valid = False

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -160,6 +160,56 @@ class TestDatabase(unittest.TestCase):
 
         self.assertEqual(result, expected)
 
+    def test_lookup_addr_name(self):
+        """``lookup_addr`` returns a dictionary when query via name param"""
+        self.mocked_cursor.fetchall.return_value = [('myTarget', '1.2.3.4', 'someComponent')]
+
+        db = database.Database()
+        result = db.lookup_addr(name='myTarget', addr=None, component=None)
+        expected = {'myTarget': {'addr': ['1.2.3.4'], 'component' : 'someComponent'}}
+
+        self.assertEqual(result, expected)
+
+    def test_lookup_addr_addr(self):
+        """``lookup_addr`` returns a dictionary when query via addr param"""
+        self.mocked_cursor.fetchall.return_value = [('myTarget', '1.2.3.4', 'someComponent')]
+
+        db = database.Database()
+        result = db.lookup_addr(name=None, addr='1.2.3.4', component=None)
+        expected = {'myTarget': {'addr': ['1.2.3.4'], 'component' : 'someComponent'}}
+
+        self.assertEqual(result, expected)
+
+    def test_lookup_addr_component(self):
+        """``lookup_addr`` returns a dictionary when query via component param"""
+        self.mocked_cursor.fetchall.return_value = [('myTarget', '1.2.3.4', 'someComponent')]
+
+        db = database.Database()
+        result = db.lookup_addr(name=None, addr=None, component='someComponent')
+        expected = {'myTarget': {'addr': ['1.2.3.4'], 'component' : 'someComponent'}}
+
+        self.assertEqual(result, expected)
+
+    def test_lookup_addr_multiple_ips(self):
+        """``lookup_addr`` returns all IPs"""
+        self.mocked_cursor.fetchall.return_value = [('myTarget', '1.2.3.4', 'someComponent'),
+                                                    ('myTarget', '2.3.4.5', 'someComponent')]
+
+        db = database.Database()
+        result = db.lookup_addr(name=None, addr=None, component='someComponent')
+        expected = {'myTarget': {'addr': ['1.2.3.4', '2.3.4.5'], 'component' : 'someComponent'}}
+
+        self.assertEqual(result, expected)
+
+    def test_lookup_addr_none(self):
+        """``lookup_addr`` returns a dictionary when all params are none"""
+        self.mocked_cursor.fetchall.return_value = [('myTarget', '1.2.3.4', 'someComponent')]
+
+        db = database.Database()
+        result = db.lookup_addr(name=None, addr=None, component=None)
+        expected = {'myTarget': {'addr': ['1.2.3.4'], 'component' : 'someComponent'}}
+
+        self.assertEqual(result, expected)
 
 if __name__ == '__main__':
     unittest.main()

--- a/vlab_ipam_api/lib/views/addr.py
+++ b/vlab_ipam_api/lib/views/addr.py
@@ -1,0 +1,86 @@
+# -*- coding: UTF-8 -*-
+"""
+A RESTful API for looking up IP address information
+"""
+import socket
+
+import ujson
+from flask_classy import request, Response
+from vlab_api_common import BaseView, describe, get_logger, requires
+
+from vlab_ipam_api.lib import const, Database
+from vlab_ipam_api.lib.exceptions import DatabaseError
+
+logger = get_logger(__name__, loglevel=const.VLAB_IPAM_LOG_LEVEL)
+
+
+class AddrView(BaseView):
+    """API end point for looking up IP address information"""
+    route_base = '/api/1/ipam/addr'
+    GET_ARGS_SCHEMA = {"$schema": "http://json-schema.org/draft-04/schema#",
+                       "type": "object",
+                       "description": "Lookup IP addresses and related meta-data. Parameters are mutually exclusive.",
+                       "properties" : {
+                           "name" : {
+                               "description": "Obtain the IP address of a component by name",
+                               "type": "string"
+                           },
+                           "addr" : {
+                               "description": "Obtain the name and component type by supplying the IP address",
+                               "type": "string"
+                           },
+                           "component": {
+                               "description": "Obtain the IP addresses and names of machines of a supplied component type",
+                               "type": "string"
+                           }
+                       },
+                      }
+
+    @requires(version=2, username=const.VLAB_IPAM_OWNER, verify=const.VLAB_VERIFY_TOKEN)
+    @describe(get_args=GET_ARGS_SCHEMA)
+    def get(self, *args, **kwargs):
+        """Display the Port Map rules defined on the NAT firewall"""
+        username = kwargs['token']['username']
+        resp_data = {'user' : username, 'content' : {}}
+        status_code = 200
+        name = request.args.get('name', None)
+        addr = request.args.get('addr', '')
+        component = request.args.get('component', None)
+        if args_valid(name=name, addr=addr, component=component):
+            with Database() as db:
+                resp_data['content'] = db.lookup_addr(name=name, addr=addr, component=component)
+        else:
+            resp_data['error'] = 'Params are mutually exclusive. Supplied: name={}, addr={}, component={}'.format(name, addr, component)
+            status_code = 400
+        resp = Response(ujson.dumps(resp_data))
+        resp.status_code = status_code
+        return resp
+
+
+def args_valid(name, addr, component):
+    """Validate that the supplied query parameters are OK.
+
+    :Returns: Boolean
+
+    :param name: The specific name of a machine in the lab to lookup the address of.
+    :type name: String
+
+    :param addr: The IP address to lookup meta data about.
+    :type addr: String
+
+    :param component: The type of vLab component to look up (i.e. OneFS, ESRS, etc)
+    :type component: String
+    """
+    ok = True
+    # Verify mutually exclusivity
+    if (name and addr and component):
+        ok = False
+    elif (name and addr) or (name and component) or (addr and component):
+        ok =  False
+    # Verify addr is an IPv4 address
+    if addr:
+        try:
+            socket.inet_aton(addr)
+        except (OSError, TypeError):
+            ok =  False
+    return ok


### PR DESCRIPTION
This will be handy for dealing with the whole _"what's the IP of my OneFS node"_ problem.

By default, the API will return all the machines (by name), their IPs, and what type of component.
Optionally, you can filter the results by a specific name or type, or perform a reverse lookup by IP (i.e. get the information of _what owns that IP_).