### PR TITLE
Feat log send

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,39 @@
 #############
 vLab IPAM API
 #############
+
+This service replaces the existing static gateway used in vLab.
+
+The goal of this service is to make it easier for users to access their lab
+by removing the need for the jumpbox. This is achieved by exposing a RESTful API
+on the gateway that can dynamically port-forward through the NAT firewall that
+runs on the gateway. Additionally, vLab clients can leverage this API to programmically
+*connect* users to a given resource. For example the vLab CLI client can potentially:
+
+1. Expose an interface like ``vlab connect windows --name <name of instance> --protocol=RDP``
+#. Call the main vLab server to *get the IP of the gateway*
+#. Call the API on the gateway to *get the port* that maps to the specific component and protocol
+#. Evoke an application *on the user's machine* that understands the specific protocol, and pre-populate the connection information.
+
+Clients can also programmically create the port forwarding rules upon component
+creation. This would remove the need for users to manually port forwarding
+rules, but clients should not prevent users from inputting their own port forwarding
+rules.
+
+Background Services
+###################
+
+The IPAM service has two background processes:
+
+vlab-worker
+***********
+
+Periodically pings IPs stored in the IPAM database. This allows the service to
+identify "bad records" and relay that information to the user.
+
+vlab-log-sender
+***************
+
+Forwards firewall logs to a remote server. The default iptables config will
+log every time a package is FORWARDed. By forwarding the logs for remote processing,
+admins of vLab can answer business questions like, *"Do they use that resource?"*

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-ipam-api",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='0.0.7',
+      version='0.0.8',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[
@@ -24,5 +24,5 @@ setup(name="vlab-ipam-api",
       description="A RESTful API for automated IPAM of a personal lab in vLab",
       long_description=open('README.rst').read(),
       install_requires=['flask', 'pyjwt', 'uwsgi', 'vlab-api-common', 'psycopg2',
-                        'ujson', 'cryptography', 'setproctitle']
+                        'ujson', 'cryptography', 'setproctitle', 'kafka-python']
       )

--- a/tests/test_file_logger.py
+++ b/tests/test_file_logger.py
@@ -1,0 +1,16 @@
+# -*- coding: UTF-8 -*-
+"""A suite of unit tests for the file_logger.py module"""
+import unittest
+from unittest.mock import patch, MagicMock
+
+from vlab_ipam_api.lib import file_logger
+
+class TestWorker(unittest.TestCase):
+    """A suite of test cases for the file_logger.py module"""
+
+    @patch.object(file_logger, 'RotatingFileHandler')
+    def test_get_logger(self, fake_RotatingFileHandler):
+        """``get_logger`` Returns a logging object"""
+        logger = file_logger.get_logger(name='testing', log_file='/some/log/file.log')
+
+        self.assertTrue(isinstance(logger, file_logger.logging.Logger))

--- a/tests/test_log_sender.py
+++ b/tests/test_log_sender.py
@@ -1,0 +1,141 @@
+# -*- coding: UTF-8 -*-
+"""A suite of tests for the log_sender.py module"""
+import types
+import unittest
+from unittest.mock import patch, MagicMock, mock_open
+
+from vlab_ipam_api import log_sender
+
+
+class TestLogSender(unittest.TestCase):
+    """A suite of test cases for the log_sender.py module"""
+    @classmethod
+    def setUpClass(cls):
+        key = log_sender.Fernet.generate_key()
+        cls.cipher = log_sender.Fernet(key)
+
+    def test_tail_generator(self):
+        """``tail`` returns a generator"""
+        fake_fp = MagicMock()
+        with patch("builtins.open", mock_open(mock=fake_fp)) as mock_file:
+            logs = log_sender.tail('/some/log/file')
+            next(logs)
+
+        self.assertTrue(isinstance(logs, types.GeneratorType))
+
+    def test_get_cipher(self):
+        """``get_cipher`` returns an object for encrypting messages"""
+        tmp_key = log_sender.Fernet.generate_key()
+        with patch("builtins.open", mock_open(read_data=tmp_key)) as mock_file:
+            cipher = log_sender.get_cipher()
+
+        self.assertTrue(isinstance(cipher, log_sender.Fernet))
+
+    def test_process_log_message(self):
+        """``process_log_message`` returns an encrypted message"""
+        # Truncated a lot of this example to increase readability
+        fake_log = MagicMock()
+        example_line = "2018-11-01T09:30:56.693495-04:00 IN=ens160 OUT=ens1 SRC=192.168.1.2 DST=10.1.1.1 WINDOW=3472 RES=0x00 "
+
+        message = log_sender.process_log_message(example_line, self.cipher, fake_log)
+        # Failure to decrypt will raise exception
+        self.cipher.decrypt(message)
+
+        self.assertTrue(isinstance(message, bytes))
+
+    def test_process_log_message_empty(self):
+        """``process_log_message`` bails early if supplied an empty log line"""
+        fake_cipher = MagicMock()
+        fake_line = ''
+        fake_log = MagicMock()
+
+        log_sender.process_log_message(fake_line, fake_cipher, fake_log)
+
+        self.assertFalse(fake_cipher.encrypt.called)
+        self.assertFalse(fake_log.error.called)
+
+    def test_process_log_message_bad_timestamp(self):
+        """``process_log_message`` returns an empty message if the line has a poorly formatted time stamp"""
+        # Truncated a lot of this example to increase readability
+        fake_log = MagicMock()
+        example_line = "Nov 11 13:01:2 IN=ens160 OUT=ens1 SRC=192.168.1.2 DST=10.1.1.1 "
+
+        message = log_sender.process_log_message(example_line, self.cipher, fake_log)
+        expected = b''
+
+        self.assertEqual(message, expected)
+
+    @patch.object(log_sender, 'KafkaProducer')
+    def test_kafka(self, fake_KafkaProducer):
+        """``Kafka`` can be instantiated"""
+        fake_log = MagicMock()
+        k = log_sender.Kafka(server='localhost:9092', topic='someTopic', log=fake_log)
+
+        self.assertTrue(isinstance(k, log_sender.Kafka))
+
+    @patch.object(log_sender, 'KafkaProducer')
+    def test_kafka_context_mgr(self, fake_KafkaProducer):
+        """``Kafka`` supports use of the 'with' statement"""
+        fake_log = MagicMock()
+        try:
+            with log_sender.Kafka(server='localhost:9092', topic='someTopic', log=fake_log) as k:
+                pass
+        except AttributeError:
+            support_with_statement = False
+        else:
+            support_with_statement = True
+
+        self.assertTrue(support_with_statement)
+
+    @patch.object(log_sender, 'KafkaProducer')
+    def test_kafka_closes(self, fake_KafkaProducer):
+        """``Kafka`` auto-closed the socket when exiting the 'with' statement"""
+        fake_conn = MagicMock()
+        fake_KafkaProducer.return_value = fake_conn
+        fake_log = MagicMock()
+
+        with log_sender.Kafka(server='localhost:9092', topic='someTopic', log=fake_log) as k:
+            pass
+
+        self.assertTrue(fake_conn.close.called)
+
+    @patch.object(log_sender, 'KafkaProducer')
+    def test_kafka_flushes(self, fake_KafkaProducer):
+        """``Kafka`` auto-closed the flushes pending messages when exiting the 'with' statement"""
+        fake_conn = MagicMock()
+        fake_KafkaProducer.return_value = fake_conn
+        fake_log = MagicMock()
+
+        with log_sender.Kafka(server='localhost:9092', topic='someTopic', log=fake_log) as k:
+            pass
+
+        self.assertTrue(fake_conn.flush.called)
+
+    @patch.object(log_sender, 'KafkaProducer')
+    def test_kafka_send(self, fake_KafkaProducer):
+        """``Kafka.send`` pushes a message to the remote server"""
+        fake_conn = MagicMock()
+        fake_KafkaProducer.return_value = fake_conn
+        fake_log = MagicMock()
+
+        k = log_sender.Kafka(server='localhost:9092', topic='someTopic', log=fake_log)
+        k.send(b'my message')
+
+        self.assertTrue(fake_conn.send.called)
+
+    @patch.object(log_sender, 'get_logger')
+    @patch.object(log_sender, 'get_cipher')
+    @patch.object(log_sender, 'KafkaProducer')
+    @patch.object(log_sender, 'tail')
+    def test_main(self, fake_tail, fake_KafkaProducer, fake_get_cipher, fake_get_logger):
+        """``main`` returns None upon exit"""
+        fake_tail.return_value = ['', '2018-11-01T09:30:56.693495-04:00 IN=ens160 OUT=ens1 SRC=192.168.1.2 DST=10.1.1.1']
+
+        output = log_sender.main()
+        expected = None
+
+        self.assertEqual(output, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -9,13 +9,6 @@ from vlab_ipam_api import worker
 class TestWorker(unittest.TestCase):
     """A suite of test cases for the worker.py module"""
 
-    @patch.object(worker, 'RotatingFileHandler')
-    def test_get_logger(self, fake_RotatingFileHandler):
-        """``get_logger`` Returns a logging object"""
-        logger = worker.get_logger(name='testing')
-
-        self.assertTrue(isinstance(logger, worker.logging.Logger))
-
     @patch.object(worker, 'pingable')
     @patch.object(worker, 'update_record')
     def test_worker_thread(self, fake_update_record, fake_pingable):

--- a/vlab_ipam_api/lib/__init__.py
+++ b/vlab_ipam_api/lib/__init__.py
@@ -2,3 +2,4 @@
 from .constants import const
 from .database import Database, DatabaseError
 from .firewall import FireWall
+from .file_logger import get_logger

--- a/vlab_ipam_api/lib/constants.py
+++ b/vlab_ipam_api/lib/constants.py
@@ -20,6 +20,7 @@ DEFINED = OrderedDict([
             ('VLAB_PORT_MAX', int(environ.get('VLAB_PORT_MAX', 50100))),
             ('VLAB_INSERT_MAX_TRIES', int(environ.get('VLAB_INSERT_MAX_TRIES', 100))),
             ('VLAB_VERIFY_TOKEN', environ.get('VLAB_VERIFY_TOKEN', False)),
+            ('VLAB_LOG_TARGET', environ.get('VLAB_LOG_TARGET', 'localhost:9092')),
           ])
 
 Constants = namedtuple('Constants', list(DEFINED.keys()))

--- a/vlab_ipam_api/lib/file_logger.py
+++ b/vlab_ipam_api/lib/file_logger.py
@@ -1,0 +1,26 @@
+# -*- coding: UTF-8 -*-
+"""Module for creating log objects"""
+import logging
+from logging.handlers import RotatingFileHandler
+
+
+def get_logger(name, log_file, loglevel='INFO'):
+    """Simple factory function for creating logging objects
+
+    :Returns: logging.Logger
+
+    :param name: The name of the logger (typically just __name__).
+    :type name: String
+
+    :param loglevel: The verbosity of the logging; ERROR, INFO, DEBUG
+    :type loglevel: String
+    """
+    logger = logging.getLogger(name)
+    logger.setLevel(loglevel.upper())
+    if not logger.handlers:
+        ch = RotatingFileHandler(log_file, maxBytes=500000, backupCount=1)
+        formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+        ch.setLevel(loglevel.upper())
+        ch.setFormatter(formatter)
+        logger.addHandler(ch)
+    return logger

--- a/vlab_ipam_api/log_sender.py
+++ b/vlab_ipam_api/log_sender.py
@@ -1,0 +1,145 @@
+# -*- coding: UTF-8 -*-
+"""This module uploads logs to a remote server"""
+import time
+
+import ujson
+from kafka import KafkaProducer
+from setproctitle import setproctitle
+from cryptography.fernet import Fernet
+
+from vlab_ipam_api.lib import const, get_logger
+
+CIPHER_KEY_FILE = '/etc/vlab/log_sender.key'
+NETFILTER_LOG_FILE = '/var/log/kern.log'
+LOG_FILE = '/var/log/vlab_ipam_log_sender.log'
+KAFKA_TOPIC = 'firewall'
+
+
+def tail(a_file):
+    """Like the Linux/Unix tail -f command
+
+    :Returns: Generator
+
+    :params a_file: The path to the file you want to follow/tail
+    :type a_file: String
+    """
+    with open(a_file) as fp:
+        fp.seek(0,2) # start at the end of the file
+        while True:
+            line = fp.readline()
+            if not line:
+                time.sleep(0.2)
+            yield line
+
+
+def get_cipher():
+    """For encrypting uploaded data
+
+    :Returns: cryptography.fernet.Fernet
+    """
+    with open(CIPHER_KEY_FILE, 'rb') as the_file:
+        key = the_file.read().strip()
+    cipher = Fernet(key)
+    return cipher
+
+
+def process_log_message(log_line, cipher, log):
+    """Evaluate if the message is from Netfilter, and generate an encrypted payload
+
+    If the supplied log message is not from Netfilter an empty stream of bytes is
+    returned.
+
+    :Returns: Bytes
+
+    :param log_line: The log message to evaluate
+    :type log_line: String
+
+    :param cipher: The instantiated object for creating an encrypted payload
+    :type cipher: cryptography.fernet.Fernet
+    """
+    source = None
+    target = None
+    date = None
+    user = None
+    message = b''
+    if not log_line:
+        return message
+    # 2018-11-01T09:30:56.693495-04:00 HOSTNAME kernel: [   31.452226] IN=ens160 OUT=ens192 MAC=00:50:56:bc:5d:f8:00:50:56:bc:9a:1e:08:00 SRC=192.168.1.2 DST=65.200.22.114 LEN=40 TOS=0x00 TTL=63 ID=23104 DF PROTO=TCP SPT=48884 DPT=80 WINDOW=3472 RES=0x00 ACK FIN URGP=0
+    chunks = log_line.split(' ')
+    for chunk in chunks:
+        if source and target:
+            break
+        elif chunk.startswith('SRC='):
+            source = chunk.split('=')[-1]
+        elif chunk.startswith('DST='):
+            target = chunk.split('=')[-1]
+    if source and target:
+        user = const.VLAB_IPAM_OWNER
+        date_string = chunks[0].split('.')[0] # strip off miliseconds and timezone
+        pattern = '%Y-%m-%dT%H:%M:%S'
+        try:
+            epoch = int(time.mktime(time.strptime(date_string, pattern)))
+        except ValueError:
+            log.error('Invalid timestamp. Format: {}, Timestamp: {}'.format(pattern, date_string))
+        else:
+            payload = ujson.dumps({'time': epoch,
+                                   'source': source,
+                                   'target': target,
+                                   'user' : user})
+            log.debug(payload)
+            message = cipher.encrypt(payload.encode()) # encode to turn into bytes
+    return message
+
+
+class Kafka(object):
+    """Makes working with the public Kafka Producer more Pythonic"""
+    def __init__(self, server, topic, log, retries=5):
+        self._conn = KafkaProducer(bootstrap_servers=server, retries=retries)
+        self._server = server
+        self._topic = topic
+        self._log = log
+        self._log.info("Connection established to {}, topic: {}".format(self._server, self._topic))
+
+    @property
+    def topic(self):
+        return self._topic
+
+    def close(self):
+        self._log.info("flushing any pending message uploads")
+        self._conn.flush()
+        self._log.info("terminating connection to {}".format(self._server))
+        self._conn.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, the_traceback):
+        self.close()
+
+    def send(self, message):
+        """Upload an encrypted message to Kafka
+
+        :Returns: None
+
+        :param message: The encrypted payload to upload
+        :type message: Bytes
+        """
+        self._conn.send(self.topic, message)
+
+
+def main():
+    """Entry point logic"""
+    log = get_logger(name=__name__, log_file=LOG_FILE)
+    log.info('Starting Log Sender')
+    cipher = get_cipher()
+    with Kafka(server=const.VLAB_LOG_TARGET, topic=KAFKA_TOPIC, log=log) as kafka:
+        for log_line in tail(NETFILTER_LOG_FILE):
+            message = process_log_message(log_line, cipher, log)
+            if message:
+                kafka.send(message)
+    log.info('Ending Log Sender')
+
+
+if __name__ == '__main__':
+    setproctitle('IPAM-log-sender')
+    main()

--- a/vlab_ipam_api/vlab-log-sender.service
+++ b/vlab_ipam_api/vlab-log-sender.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Background worker upload firewall logs for processing
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/python3 log_sender.py
+WorkingDirectory=/usr/local/lib/python3.6/dist-packages/vlab_ipam_api
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/vlab_ipam_api/worker.py
+++ b/vlab_ipam_api/worker.py
@@ -4,12 +4,10 @@ import sys
 import time
 import queue
 import threading
-import logging
-from logging.handlers import RotatingFileHandler
 
 from setproctitle import setproctitle
 
-from vlab_ipam_api.lib import const, shell, Database
+from vlab_ipam_api.lib import const, shell, Database, get_logger
 
 
 LOOP_INTERVAL = 300 # seconds
@@ -17,28 +15,6 @@ THREAD_POLL_TIMEOUT = 10 # seconds
 THREAD_COUNT = 10
 LOG_FILE = '/var/log/vlab_ipam_worker.log'
 PING_SYNTAX = '/bin/ping -W 2 -c 3 -4 -I ens192 {}'
-
-
-def get_logger(name, loglevel='INFO'):
-    """Simple factory function for creating logging objects
-
-    :Returns: logging.Logger
-
-    :param name: The name of the logger (typically just __name__).
-    :type name: String
-
-    :param loglevel: The verbosity of the logging; ERROR, INFO, DEBUG
-    :type loglevel: String
-    """
-    logger = logging.getLogger(name)
-    logger.setLevel(loglevel.upper())
-    if not logger.handlers:
-        ch = RotatingFileHandler(LOG_FILE, maxBytes=500000, backupCount=1)
-        formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
-        ch.setLevel(loglevel.upper())
-        ch.setFormatter(formatter)
-        logger.addHandler(ch)
-    return logger
 
 
 class Worker(threading.Thread):
@@ -209,7 +185,7 @@ def make_workers(work_queue, logger):
 def main():
     """Entry point logic for validating IP records"""
     work_queue = queue.Queue()
-    logger = get_logger(name=__name__)
+    logger = get_logger(name=__name__, log_file=LOG_FILE)
     logger.info('IPAM Address Probe Starting')
     logger.info('Starting {} worker threads'.format(THREAD_COUNT))
     worker_threads = make_workers(work_queue, logger)

--- a/vm/configure.sh
+++ b/vm/configure.sh
@@ -154,7 +154,8 @@ setup_webapp () {
   systemctl enable vlab-ipam
   ln -s /usr/local/lib/python3.6/dist-packages/vlab_ipam_api/vlab-worker.service /etc/systemd/system/vlab-worker.service
   systemctl enable vlab-worker
-  echo "VLAB_URL=https://vlab-dev.igs.corp" >> /etc/environment
+  ln -s /usr/local/lib/python3.6/dist-packages/vlab_ipam_api/vlab-worker.service /etc/systemd/system/vlab-log-sender.service
+  systemctl enable vlab-log-sender
 }
 
 setup_sudo () {
@@ -195,6 +196,11 @@ sed -i -e 's/local   all             postgres                                pee
   ALTER DEFAULT PRIVILEGES IN SCHEMA public
     GRANT SELECT ON TABLES TO readonly;
   "
+}
+
+setup_rsyslog () {
+  # This function changes the timestamp format used by rsyslog
+sed -i -e 's/$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat/#$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat/g' /etc/rsyslog.conf
 }
 
 clean_up () {


### PR DESCRIPTION
This feature introduces another background worker. The point of this one is to help answer business questions about usage. It's much easier to justify more hardware if you can provide data saying _"yeah, they are using this stuff all the time,"_ or take action when there's resource contention due to user's _making and not using_ components in their lab.

This specific implementation is limited to uploading messages to an instance of Apache Kafka.
I started reading up on how to [secure Kafka](https://www.confluent.io/blog/apache-kafka-security-authorization-authentication-encryption/), and while that blog is a bit old it seems like it's still pretty much how the process works. That amount of configuration overhead felt like a bit much, especially for a Kafka noob like myself.

For this initial implementation I choose to simply encrypt the JSON messages with AES. This is still useful even on a secured Kafka cluster (the whole [encryption at rest](https://en.wikipedia.org/wiki/Data_at_rest#Encryption) thing), and enables consumers to know when an untrusted entity created a given message.