### PR TITLE
/api/1/ipam/addr is avilable to all now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-ipam-api",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='0.0.8',
+      version='0.0.9',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_addr_view.py
+++ b/tests/test_addr_view.py
@@ -21,7 +21,6 @@ class TestAddrView(unittest.TestCase):
         """Runs once for the whole test suite"""
         cls.token = generate_v2_test_token(username='bob')
         addr.const = MagicMock()
-        addr.const.VLAB_IPAM_OWNER = 'bob'
         addr.const.VLAB_IPAM_LOG_LEVEL = 'INFO'
         addr.const.VLAB_VERIFY_TOKEN = False
 

--- a/vlab_ipam_api/lib/views/addr.py
+++ b/vlab_ipam_api/lib/views/addr.py
@@ -36,7 +36,7 @@ class AddrView(BaseView):
                        },
                       }
 
-    @requires(version=2, username=const.VLAB_IPAM_OWNER, verify=const.VLAB_VERIFY_TOKEN)
+    @requires(version=2, verify=const.VLAB_VERIFY_TOKEN)
     @describe(get_args=GET_ARGS_SCHEMA)
     def get(self, *args, **kwargs):
         """Display the Port Map rules defined on the NAT firewall"""


### PR DESCRIPTION
While working on the `log_sender.py` module, I realized that it would be handy to map IPs that are noted in the Netfilter logs to types and names of components. After talking with a handful of different people, no one saw any issue with (basically) making a user's inventory publicly accessible other users with a valid vLab auth token.