### PR TITLE
different gateways should get unique IP now

### DIFF
--- a/vm/configure.sh
+++ b/vm/configure.sh
@@ -207,6 +207,9 @@ sed -i -e 's/$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat/#$ActionFi
 }
 
 clean_up () {
+  # fix issue with different VMs getting same DHCP addr
+  # https://github.com/chef/bento/issues/1062
+  echo "" > /etc/machine-id
   # Remove any lingering junk and get the VM ready for cloning
   echo "Cleaning up junk"
   rm configure.sh


### PR DESCRIPTION
Thank god someone else already figured this on out. Noticed that all the different gateways being made would get the same DHCP address, even though they have unique MACs on the NIC.

Lucky, the peeps at Chef have a similar workflow to us and figured out how to address that:
https://github.com/chef/bento/issues/1062