### PR TITLE
fixed SQL syntax when lookup port map info

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-ipam-api",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='2018.12.13',
+      version='2018.12.20',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -229,7 +229,7 @@ class TestDatabase(unittest.TestCase):
 
         call_args, _ = self.mocked_cursor.execute.call_args
         sql, call_params = call_args
-        expected_sql = 'SELECT conn_port, target_addr, target_name, target_port, target_component FROM ipam WHERE name LIKE (%s);'
+        expected_sql = 'SELECT conn_port, target_addr, target_name, target_port, target_component FROM ipam WHERE target_name LIKE (%s);'
         expected_params = ('foo',)
 
         self.assertEqual(sql, expected_sql)
@@ -281,7 +281,7 @@ class TestDatabase(unittest.TestCase):
 
         call_args, _ = self.mocked_cursor.execute.call_args
         sql, call_params = call_args
-        expected_sql = 'SELECT conn_port, target_addr, target_name, target_port, target_component FROM ipam WHERE name LIKE (%s) AND target_addr LIKE (%s) AND target_component LIKE (%s) AND conn_port = (%s);'
+        expected_sql = 'SELECT conn_port, target_addr, target_name, target_port, target_component FROM ipam WHERE target_name LIKE (%s) AND target_addr LIKE (%s) AND target_component LIKE (%s) AND conn_port = (%s);'
         expected_params = ('myVM', '1.2.3.4', 'CEE', 9001,)
 
         self.assertEqual(sql, expected_sql)

--- a/vlab_ipam_api/lib/database.py
+++ b/vlab_ipam_api/lib/database.py
@@ -197,7 +197,7 @@ class Database(object):
         clauses = []
         params = []
         if name:
-            clauses.append("name LIKE (%s)")
+            clauses.append("target_name LIKE (%s)")
             params.append(name)
         if addr:
             clauses.append('target_addr LIKE (%s)')


### PR DESCRIPTION
Found this while testing the CLI client to delete a port mapping rule. Simple enough fix (really wish I had code reviewers; feels like another bug that would have been caught by a CR).