### PR TITLE
defaulting DHCP DNS to google

### DIFF
--- a/vm/configure.sh
+++ b/vm/configure.sh
@@ -47,7 +47,7 @@ echo '
 # dhcpd.conf configuration file
 
 option domain-name "vlab.local";
-option domain-name-servers 10.7.190.6, 10.7.190.7;
+option domain-name-servers 8.8.8.8;
 
 default-lease-time 600;
 max-lease-time 7200;


### PR DESCRIPTION
This is just a better default, and it makes it simpler for the [Gateway Sevice](https://github.com/willnx/vlab_gateway) to change the DNS server to the new [vLab DNS service](https://github.com/willnx/vlab_dns)