### PR TITLE
IPAM server can now send DDNS updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,3 +37,9 @@ vlab-log-sender
 Forwards firewall logs to a remote server. The default iptables config will
 log every time a package is FORWARDed. By forwarding the logs for remote processing,
 admins of vLab can answer business questions like, *"Do they use that resource?"*
+
+
+vlab-ddns-updater
+*****************
+
+Runs on a regular cycle to send Dynamic DNS updates to the vLab DNS service.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-ipam-api",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='2018.12.27',
+      version='2019.01.18',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[
@@ -24,5 +24,6 @@ setup(name="vlab-ipam-api",
       description="A RESTful API for automated IPAM of a personal lab in vLab",
       long_description=open('README.rst').read(),
       install_requires=['flask', 'pyjwt', 'uwsgi', 'vlab-api-common', 'psycopg2',
-                        'ujson', 'cryptography', 'setproctitle', 'kafka-python']
+                        'ujson', 'cryptography', 'setproctitle', 'kafka-python',
+                        'dnspython']
       )

--- a/vlab_ipam_api/ddns_updater.py
+++ b/vlab_ipam_api/ddns_updater.py
@@ -1,0 +1,129 @@
+# -*- coding: UTF-8 -*-
+"""This script will send Dynamic DNS updates to the vLab DNS service"""
+import time
+import json
+import fcntl
+import socket
+import struct
+
+import dns.query
+import dns.update
+import dns.tsigkeyring
+from setproctitle import setproctitle
+
+from vlab_ipam_api.lib import const, get_logger
+
+LOG_FILE = '/var/log/vlab_ipam_ddns_updater.log'
+DDNS_KEY = '/etc/vlab/ddns_key.json'
+VLAB_KEYNAME = 'DDNS_UPDATE' # The name of the key in the bind9 config defined in /etc/bind/ddns.key
+
+
+def get_ip(iface='ens160'):
+    """Obtain the current IP of the WAN interface
+
+    :Returns: String
+
+    :param iface: The name of the network interface that owns the IP
+    :type iface: String
+    """
+    interface = iface.encode()[:15] # Prevent lower lib from barfing over too long of iface name
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    data = fcntl.ioctl(s.fileno(),
+                       0x8915, # SIOCGIFADDR - http://man7.org/linux/man-pages/man7/netdevice.7.html
+                       struct.pack('256s', interface))
+    ip = socket.inet_ntoa(data[20:24]) # the IPv4 addr is the 4 bytes in this range
+    return ip
+
+
+def get_hostname():
+    """Obtain the hostname of this gateway"""
+    name = socket.gethostname()
+    return name.split('.')[0]
+
+
+def get_ddns_key_info():
+    """Obtain the DDNS key and algorithm from a JSON file
+
+    Returns: Tuple (keyring, algorithm)
+    """
+    keyring = dns.tsigkeyring.from_text({VLAB_KEYNAME : const.VLAB_DDNS_KEY})
+    return keyring, const.VLAB_DDNS_ALGORITHM
+
+
+def update_a_record(hostname, ip, domain, keyring, algorithm):
+    """Update the DNS record
+
+    :Returns: None
+
+    :param hostname: The name to give the DNS record
+    :type hostname: String
+
+    :param ip: The IP the hostname should map to
+    :type ip: String
+
+    :param domain: The FQDN of the vLab server
+    :type domain: String
+
+    :param keyring: The dnssec creds required for making an update
+    :type keyring: dns.tsigkeyring.from_text
+
+    :type algorithm: The encryption method used for the keyring creds
+    :type algorithm: String
+    """
+    update = dns.update.Update(domain, keyring=keyring, keyalgorithm=algorithm)
+    update.replace(hostname, 300, 'a', ip) # 'a' means A-record, 300 is the TTL
+    dns.query.tcp(update, domain)
+
+
+def main():
+    """Entry point for script"""
+    log = get_logger(name=__name__, log_file=LOG_FILE)
+    log.info('DDNS updater starting')
+    keyring, algorithm = get_ddns_key_info()
+    domain = const.VLAB_URL.replace("https://", "").replace("http://", "")
+    hostname = get_hostname()
+    loop_interval = 5
+    max_update_period = 120
+    update_regardless = int(max_update_period / loop_interval)
+    log.info('Checking for updated IP every {} seconds'.format(loop_interval))
+    log.info('Sending DDNS update regardless of new IP every {} seconds'.format(max_update_period))
+    current_ip = None
+    count = 0
+    while True:
+        start_time = time.time()
+        new_ip = get_ip()
+        if new_ip != current_ip:
+            log.info('IP updated, was {}, now is {}'.format(current_ip, new_ip))
+            try:
+                update_a_record(hostname=hostname,
+                                domain=domain,
+                                ip=new_ip,
+                                keyring=keyring,
+                                algorithm=algorithm)
+            except Exception as doh:
+                log.exception(doh)
+            else:
+                # Only update our ref to the IP if the DNS server accepted it
+                current_ip = new_ip
+                log.info('Updated IP, current IP is {}'.format(current_ip))
+        else:
+            # By updating every few minutes we allow the DNS server to be stateless
+            # at the cost of eventual consistency; i.e. it'll break, but it'll
+            # also resolve itself once all the gateways send the update.
+            if count % update_regardless == 0:
+                log.info('Sending DDNS update because it\'s been at least {} seconds since last update'.format(max_update_period))
+                update_a_record(hostname=hostname,
+                                domain=domain,
+                                ip=new_ip,
+                                keyring=keyring,
+                                algorithm=algorithm)
+        count += 1
+        elapsed_time = time.time() - start_time
+        loop_delta = max(loop_interval - elapsed_time, 0) # avoid negative sleep
+        log.info('Will start next IP check in {} seconds'.format(loop_delta))
+        time.sleep(loop_delta)
+
+
+if __name__ == '__main__':
+    setproctitle('IPAM-ddns-updater')
+    main()

--- a/vlab_ipam_api/lib/constants.py
+++ b/vlab_ipam_api/lib/constants.py
@@ -21,6 +21,8 @@ DEFINED = OrderedDict([
             ('VLAB_INSERT_MAX_TRIES', int(environ.get('VLAB_INSERT_MAX_TRIES', 100))),
             ('VLAB_VERIFY_TOKEN', environ.get('VLAB_VERIFY_TOKEN', False)),
             ('VLAB_LOG_TARGET', environ.get('VLAB_LOG_TARGET', 'localhost:9092')),
+            ('VLAB_DDNS_KEY', environ.get('VLAB_DDNS_KEY', 'PpULFMK6UQXYhFUot++fhNcmAumx+N7GcRfzO75NgL6RBA3gdJrw1KwraVR4QkhNoL23ySpdgTpWA1dUke2ZsA==')),
+            ('VLAB_DDNS_ALGORITHM', environ.get('VLAB_DDNS_ALGORITHM', 'HMAC-SHA512')),
           ])
 
 Constants = namedtuple('Constants', list(DEFINED.keys()))

--- a/vlab_ipam_api/vlab-ddns-updater.service
+++ b/vlab_ipam_api/vlab-ddns-updater.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=DDNS update client for vLab
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/environment
+ExecStart=/usr/bin/python3 ddns_updater.py
+WorkingDirectory=/usr/local/lib/python3.6/dist-packages/vlab_ipam_api
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/vm/configure.sh
+++ b/vm/configure.sh
@@ -222,6 +222,8 @@ add_envvars () {
   echo "VLAB_LOG_TARGET=localhost:9092" >> /etc/environment
   echo "VLAB_URL=https://localhost" >> /etc/environment
   echo "PRODUCTION=false" >> /etc/environment
+  echo "VLAB_DDNS_KEY=aabbcc" >> /etc/environment
+  echo "VLAB_DDNS_ALGORITHM=HMAC-SHA512" >> /etc/environment
 }
 
 add_logsender_key () {


### PR DESCRIPTION
This update to the IPAM server is part of the work needed for https://github.com/willnx/vlab/issues/9.

With this update, the IPAM server will send DDNS updates to the vLab DNS service . By default, the system checks for a new IP every 5 seconds. After every 2 minutes, regardless if the IP has changed or not, a DDNS update will be sent. The idea behind the _send regardless_ aspect is to enable the vLab DNS service to remain stateless. If an update was _only_ sent when the IP changes, then the DNS service would have to persist the dynamic records through restarts of the DNS service.

The service isn't always sending an update to simply lower noise/traffic. When 500 of these things start running, the DNS service would average 100 update requests per second, which feels like over kill. This does mean that there's a 2 minute window after restarting the DNS service where _things wont work_ for users. This feels acceptable because A) it fixes itself and B) maintenance windows exist for a reason.