### PR TITLE
Fixed intergation bugs with using DDNS

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include vlab_ipam_api/app.ini
 include vlab_ipam_api/vlab-ipam.service
 include vlab_ipam_api/vlab-worker.service
 include vlab_ipam_api/vlab-log-sender.service
+include vlab_ipam_api/vlab-ddns-updater.service

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-ipam-api",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='2019.01.18',
+      version='2019.01.19',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/vlab_ipam_api/ddns_updater.py
+++ b/vlab_ipam_api/ddns_updater.py
@@ -72,7 +72,7 @@ def update_a_record(hostname, ip, domain, keyring, algorithm):
     """
     update = dns.update.Update(domain, keyring=keyring, keyalgorithm=algorithm)
     update.replace(hostname, 300, 'a', ip) # 'a' means A-record, 300 is the TTL
-    dns.query.tcp(update, domain)
+    dns.query.udp(update, domain)
 
 
 def main():

--- a/vm/configure.sh
+++ b/vm/configure.sh
@@ -116,6 +116,8 @@ setup_nat () {
   # Enable outbound DNS
   iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
   iptables -A INPUT -p udp --sport 53 -j ACCEPT
+  iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+  iptables -A INPUT -p tcp --sport 53 -j ACCEPT
 
   # Enable incoming SSH access
   iptables -A INPUT -p tcp --dport 22 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
@@ -156,6 +158,8 @@ setup_webapp () {
   systemctl enable vlab-worker
   ln -s /usr/local/lib/python3.6/dist-packages/vlab_ipam_api/vlab-log-sender.service /etc/systemd/system/vlab-log-sender.service
   systemctl enable vlab-log-sender
+  ln -s /usr/local/lib/python3.6/dist-packages/vlab_ipam_api/vlab-ddns-updater.service /etc/systemd/system/vlab-ddns-updater.service
+  systemctl enable vlab-ddns-updater
 }
 
 setup_sudo () {

--- a/vm/configure.sh
+++ b/vm/configure.sh
@@ -133,6 +133,10 @@ setup_nat () {
   iptables -A OUTPUT -p tcp --dport 80 -m state --state NEW,ESTABLISHED -j ACCEPT
   iptables -A INPUT -p tcp --sport 80 -m state --state ESTABLISHED -j ACCEPT
 
+  # Enable NTP
+  iptables -A OUTPUT -p udp --dport 123 -j ACCEPT
+  iptables -A INPUT -p udp --sport 123 -j ACCEPT
+
   # Enable ICMP (aka ping)
   iptables -A INPUT -p icmp --icmp-type echo-request -j ACCEPT
   iptables -A INPUT -p icmp --icmp-type echo-reply -j ACCEPT


### PR DESCRIPTION
Found a couple of _derp bug_ when testing the new ddns_updater service for IPAM, and fixed them.

One of the bugs is a time-sync deal. Like DDNS updates are sensitive to clock skews between the devices (probably to prevent replay attacks). I opened the NTP protocol in the IPAM firewall, but I think running an NTP server in the same vein as the vLab DNS service will be needed. 