### PR TITLE
IPAM server supports NTP

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-ipam-api",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='2019.01.19',
+      version='2019.01.21',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[


### PR DESCRIPTION
This update is related to https://github.com/willnx/vlab/issues/9

While working on the DDNS update feature (https://github.com/willnx/vlab_ipam_api/pull/13), I learned that DDNS updates are time-sensitive. This make sense, but requires that the DNS server and the client sending the update to have similar timestamps.

After doing a bit of research, I choose [chrony](https://chrony.tuxfamily.org/index.html). While setting up the NTP client, I figured making the gateway an NTP server would also be a good idea. This way, users can just sync to it for the 80% use-case of needing NTP in their lab. I image the same pattern will occur for a DNS (caching) server, and an SMTP relay server (i.e. need a `<insert common service here>`, just use _your_ gateway).