### PR TITLE
Bug systemd timeout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-ipam-api",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='2019.01.24',
+      version='2019.02.13',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/vlab_ipam_api/app.ini
+++ b/vlab_ipam_api/app.ini
@@ -11,7 +11,6 @@ http-gid = nogroup
 disable-logging = true
 enabled-threads = true
 buffer-size=32768
-daemonize = /var/log/vlab_ipam.log
 log-truncate = True
 logfile-chmod = 644
 vacuum = true


### PR DESCRIPTION
I'm an idiot... 😅 Systemd expects the process it starts to not fork itself. Removing the `daemonize` option form the `app.ini` makes the uWSGI webserver run in the foreground. This fixes two issues:

1) Slow reboots awaiting systemd to kill the uWSGI webserver
2) Constant restarts of the process every 90 seconds

I noticed this problem while looking at the Auth API logs, and seeing that the API gateways were pinging for the auth key every ~90 seconds.

Tested this change locally on my gateway to confirm this change fixes those two problems.