### PR TITLE
Query by target_port on PortMapView for GET requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-ipam-api",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='2019.02.13',
+      version='2019.02.19',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -274,15 +274,28 @@ class TestDatabase(unittest.TestCase):
         self.assertEqual(sql, expected_sql)
         self.assertEqual(call_params, expected_params)
 
-    def test_lookup_port_by_all(self):
-        """``lookup_port`` generates correct SQL when the all clauses are supplied"""
+    def test_lookup_port_by_target_port(self):
+        """``lookup_port`` generates correct SQL when the "target_port" clause is supplied"""
         db = database.Database()
-        db.lookup_port(name='myVM', addr='1.2.3.4', component='CEE', conn_port=9001)
+        db.lookup_port(target_port=22)
 
         call_args, _ = self.mocked_cursor.execute.call_args
         sql, call_params = call_args
-        expected_sql = 'SELECT conn_port, target_addr, target_name, target_port, target_component FROM ipam WHERE target_name LIKE (%s) AND target_addr LIKE (%s) AND target_component LIKE (%s) AND conn_port = (%s);'
-        expected_params = ('myVM', '1.2.3.4', 'CEE', 9001,)
+        expected_sql = 'SELECT conn_port, target_addr, target_name, target_port, target_component FROM ipam WHERE target_port = (%s);'
+        expected_params = (22,)
+
+        self.assertEqual(sql, expected_sql)
+        self.assertEqual(call_params, expected_params)
+
+    def test_lookup_port_by_all(self):
+        """``lookup_port`` generates correct SQL when the all clauses are supplied"""
+        db = database.Database()
+        db.lookup_port(name='myVM', addr='1.2.3.4', component='CEE', conn_port=9001, target_port=443)
+
+        call_args, _ = self.mocked_cursor.execute.call_args
+        sql, call_params = call_args
+        expected_sql = 'SELECT conn_port, target_addr, target_name, target_port, target_component FROM ipam WHERE target_name LIKE (%s) AND target_addr LIKE (%s) AND target_component LIKE (%s) AND conn_port = (%s) AND target_port = (%s);'
+        expected_params = ('myVM', '1.2.3.4', 'CEE', 9001, 443)
 
         self.assertEqual(sql, expected_sql)
         self.assertEqual(call_params, expected_params)

--- a/tests/test_portmap_view.py
+++ b/tests/test_portmap_view.py
@@ -56,7 +56,7 @@ class TestPortMapView(unittest.TestCase):
 
     @patch.object(portmap, 'Database')
     def test_get_bad_conn_port(self, fake_Database):
-        """GET on /api/1/ipam/portmap returns HTTP 400 is supplied with a bad value"""
+        """GET on /api/1/ipam/portmap returns HTTP 400 is supplied with a bad value for conn_port"""
         fake_db = MagicMock()
         fake_db.lookup_port.return_value = {'worked': True}
         fake_Database.return_value.__enter__.return_value = fake_db
@@ -67,6 +67,18 @@ class TestPortMapView(unittest.TestCase):
 
         self.assertEqual(resp.status_code, expected)
 
+    @patch.object(portmap, 'Database')
+    def test_get_bad_target_port(self, fake_Database):
+        """GET on /api/1/ipam/portmap returns HTTP 400 is supplied with a bad value for target_port"""
+        fake_db = MagicMock()
+        fake_db.lookup_port.return_value = {'worked': True}
+        fake_Database.return_value.__enter__.return_value = fake_db
+        resp = self.app.get('/api/1/ipam/portmap?target_port=asdf',
+                            headers={'X-Auth': self.token})
+
+        expected = 400
+
+        self.assertEqual(resp.status_code, expected)
     @patch.object(portmap, 'Database')
     def test_get_doh_status(self, fake_Database):
         """GET on /api/1/ipam/portmap returns HTTP 500 upon error"""

--- a/vlab_ipam_api/lib/database.py
+++ b/vlab_ipam_api/lib/database.py
@@ -176,7 +176,7 @@ class Database(object):
                 ips.append(the_addr)
         return answer
 
-    def lookup_port(self, name=None, addr=None, component=None, conn_port=None):
+    def lookup_port(self, name=None, addr=None, component=None, conn_port=None, target_port=None):
         """Obtain port mapping information
 
         :Returns: Dictionary
@@ -189,6 +189,9 @@ class Database(object):
 
         :param component: The category of VM (i.e. OneFS, InsightIQ, etc)
         :type component: String
+
+        :param conn_port: The connection port
+        :type conn_port: Integer
 
         :param conn_port: The connection port
         :type conn_port: Integer
@@ -208,6 +211,9 @@ class Database(object):
         if conn_port:
             clauses.append('conn_port = (%s)')
             params.append(conn_port)
+        if target_port:
+            clauses.append('target_port = (%s)')
+            params.append(target_port)
         where = ' AND '.join(clauses)
         if where:
             query = "{} WHERE {};".format(sql, where)


### PR DESCRIPTION
While updating the CLI to remove all the business logic for communication with the IPAM API, I realized that filtering based on `target_port` would be really useful. The CLI will _already know_ what the target port and component name is when calling the IPAM API. This update enables the CLI to avoid looping over the results to _find the right port_ to delete.