### PR TITLE
Pre prod updates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-ipam-api",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='2019.02.20',
+      version='2019.02.22',
       packages=find_packages(),
       include_package_data=True,
       classifiers=[

--- a/tests/test_portmap_view.py
+++ b/tests/test_portmap_view.py
@@ -40,9 +40,11 @@ class TestPortMapView(unittest.TestCase):
         cls.fake_logger = MagicMock()
         portmap.logger = cls.fake_logger
 
+    @patch.object(portmap, 'get_ip')
     @patch.object(portmap, 'Database')
-    def test_get(self, fake_Database):
+    def test_get(self, fake_Database, fake_ip):
         """GET on /api/1/ipam/portmap returns the port mapping rules"""
+        fake_ip.return_value = 'some.ip.value'
         fake_db = MagicMock()
         fake_db.lookup_port.return_value = {'worked': True}
         fake_Database.return_value.__enter__.return_value = fake_db
@@ -50,7 +52,7 @@ class TestPortMapView(unittest.TestCase):
                             headers={'X-Auth': self.token})
 
         output = resp.json['content']
-        expected = {'worked': True}
+        expected = {'gateway_ip': 'some.ip.value', 'ports': {'worked': True}}
 
         self.assertEqual(output, expected)
 

--- a/vlab_ipam_api/lib/views/portmap.py
+++ b/vlab_ipam_api/lib/views/portmap.py
@@ -10,6 +10,7 @@ from flask_classy import request, Response
 from vlab_api_common import BaseView, describe, get_logger, requires, validate_input
 
 from vlab_ipam_api.lib import const, Database
+from vlab_ipam_api.ddns_updater import get_ip
 from vlab_ipam_api.lib.exceptions import DatabaseError, CliError
 
 logger = get_logger(__name__, loglevel=const.VLAB_IPAM_LOG_LEVEL)
@@ -99,14 +100,16 @@ class PortMapView(BaseView):
             return resp
         try:
             with Database() as db:
-                resp_data['content'] = db.lookup_port(name=name, addr=addr,
-                                                      component=component,
-                                                      conn_port=conn_port,
-                                                      target_port=target_port)
+                resp_data['content']['ports'] = db.lookup_port(name=name, addr=addr,
+                                                               component=component,
+                                                               conn_port=conn_port,
+                                                               target_port=target_port)
         except Exception as doh:
             logger.exception(doh)
             resp_data['error'] = '%s' % doh
             status_code = 500
+        else:
+            resp_data['content']['gateway_ip'] = get_ip()
         resp = Response(ujson.dumps(resp_data))
         resp.status_code = status_code
         return resp

--- a/vm/configure.sh
+++ b/vm/configure.sh
@@ -124,7 +124,7 @@ setup_nat () {
 
   # Enable DNS queries from remote VMs
   iptables -A INPUT -p udp -m udp --dport 53 -j ACCEPT
-  iptables -A OUTPUT -p udp -m udp --sport 53 -j ACCEPT 
+  iptables -A OUTPUT -p udp -m udp --sport 53 -j ACCEPT
 
   # Enable incoming SSH access
   iptables -A INPUT -p tcp --dport 22 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
@@ -163,7 +163,7 @@ setup_cert () {
 setup_webapp () {
   echo "Installing IPAM software"
   # This function installs the RESTful API for managaing the vLab Firewall
-  pip3 install vlab-ipam-api
+  pip3 --trusted-host pypi.org --trusted-host files.python.org install vlab-ipam-api
   ln -s /usr/local/lib/python3.6/dist-packages/vlab_ipam_api/vlab-ipam.service /etc/systemd/system/vlab-ipam.service
   systemctl enable vlab-ipam
   ln -s /usr/local/lib/python3.6/dist-packages/vlab_ipam_api/vlab-worker.service /etc/systemd/system/vlab-worker.service


### PR DESCRIPTION
While re-rolling the IPAM OVA, I noticed that the CORP firewall _got weird_ when installing python packages. So I updated the pip command to trust pypi regardless of what a CORP firewall does to the connection.

Also, while poking around with the vLab CLI, I noticed that I had to make additional API calls to find the Gateway IP when using the portmap data. For instance, `vlab connect ...` needed both the port and the user's gateway IP. Also, providing portmap rule information for users is more handy if you give them the IP that they need to use the port on. So, I figured now is a great time to make a response-breaking API change.