### PR TITLE
Added libpq-dev because psycopg2 now needs it to compile

### DIFF
--- a/vm/configure.sh
+++ b/vm/configure.sh
@@ -22,7 +22,8 @@ install_deb_deps () {
   apt-get upgrade -y
   apt-get install -y openssl libssl-dev python3 python3-dev gcc python3-pip \
                      isc-dhcp-server open-vm-tools openssh-server iptables-persistent \
-                     postgresql postgresql-contrib libpcre3 libpcre3-dev chrony bind9
+                     postgresql postgresql-contrib libpcre3 libpcre3-dev chrony bind9 \
+                     libpq-dev
 }
 
 setup_nics () {


### PR DESCRIPTION
Not sure why, but `psycopg2` now needs this system package to compile. Easy enough to fix though 😸 